### PR TITLE
Fix missing image

### DIFF
--- a/data/svema.json
+++ b/data/svema.json
@@ -140,7 +140,7 @@
     },
     {
       "name": "svema_19",
-      "imagebig": "http://simonstalenhag.se/4k/svema_19_big.jpg",
+      "imagebig": "http://simonstalenhag.se/bilder/svema_19_big.jpg",
       "image": "http://simonstalenhag.se/bilder/svema_19.jpg",
       "section": "SWEDISH MACHINES (2024)"
     },


### PR DESCRIPTION
Hi, I found that an image leads to a 404, the image is from Sweden Machine.
The imagebig image is missing from Stålenhag's website, even though it is linked in the HTML, I think he messed up
I can't find the higher quality picture on his website